### PR TITLE
Improve admin UI and add simple user management

### DIFF
--- a/public/css/admin.css
+++ b/public/css/admin.css
@@ -109,3 +109,5 @@ h1, h2, h3, h4 {
   margin-left: 0;
 }
 
+
+.dashboard-tile { cursor: pointer; color: #fff; }

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -35,6 +35,9 @@ router.use('/admin', (req, res, next) => {
   if (!req.session.user) {
     return res.redirect('/admin/login');
   }
+  if (req.path.startsWith('/users') && req.session.user.role !== 'admin') {
+    return res.status(403).send('Forbidden');
+  }
   next();
 });
 

--- a/routes/users.js
+++ b/routes/users.js
@@ -1,0 +1,38 @@
+const express = require('express');
+const router = express.Router();
+const bcrypt = require('bcrypt');
+const connectToDB = require('../config/db');
+
+function requireAdmin(req, res, next) {
+  if (!req.session?.user || req.session.user.role !== 'admin') {
+    return res.status(403).send('Forbidden');
+  }
+  next();
+}
+
+router.get('/', requireAdmin, async (req, res) => {
+  try {
+    const db = await connectToDB();
+    const users = await db.collection('users').find({}, { projection: { password: 0 } }).toArray();
+    res.json(users.map(u => ({ id: u._id.toString(), username: u.username, role: u.role })));
+  } catch (err) {
+    console.error('Fetch users error:', err);
+    res.status(500).send('Server error');
+  }
+});
+
+router.post('/', requireAdmin, async (req, res) => {
+  const { username, password, role } = req.body;
+  if (!username || !password || !role) return res.status(400).send('Missing fields');
+  try {
+    const hash = await bcrypt.hash(password, 12);
+    const db = await connectToDB();
+    await db.collection('users').insertOne({ username, password: hash, role });
+    res.status(201).send('User created');
+  } catch (err) {
+    console.error('Create user error:', err);
+    res.status(500).send('Server error');
+  }
+});
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -29,6 +29,8 @@ app.get('/admin/dashboard', (req, res) => res.sendFile(path.join(__dirname, 'vie
 app.get('/admin/bookings', (req, res) => res.sendFile(path.join(__dirname, 'views/admin/list-bookings.html')));
 app.get('/admin/finance', (req, res) => res.sendFile(path.join(__dirname, 'views/admin/finance.html')));
 app.get('/admin/users', (req, res) => res.sendFile(path.join(__dirname, 'views/admin/users.html')));
+app.get('/admin/profile', (req, res) => res.sendFile(path.join(__dirname, 'views/admin/profile.html')));
+app.get('/admin/settings', (req, res) => res.sendFile(path.join(__dirname, 'views/admin/settings.html')));
 app.get('/admin/villas/list', (req, res) => res.sendFile(path.join(__dirname, 'views/admin/list-villas.html')));
 app.get('/admin/villas/add', (req, res) => res.sendFile(path.join(__dirname, 'views/admin/add-villa.html')));
 app.get('/admin/villas/edit', (req, res) => res.sendFile(path.join(__dirname, 'views/admin/edit-villa.html')));
@@ -47,10 +49,12 @@ const roomsRouter = require('./routes/rooms');
 const bookingsRouter = require('./routes/bookings');
 const authRouter = require('./routes/auth');
 const devRoutes = require('./routes/dev');
+const usersRouter = require('./routes/users');
 
 app.use('/api/villas', villasRouter);
 app.use('/api/rooms', roomsRouter);
 app.use('/api/bookings', bookingsRouter);
+app.use('/api/users', usersRouter);
 app.use('/dev', devRoutes);
 app.use(authRouter); // Already prefixed inside
 

--- a/views/admin/add-room.html
+++ b/views/admin/add-room.html
@@ -30,20 +30,13 @@
   <div class="main-content">
     <div class="topbar d-flex justify-content-between align-items-center">
       <button class="btn btn-light" id="sidebarToggle">&#9776;</button>
-    <a href="#">Finance</a>
-    <a href="#">Users Management</a>
-    <a href="#">Settings</a>
-  </div>
-
-  <div class="main-content">
-    <div class="topbar d-flex justify-content-end align-items-center">
       <div class="dropdown">
         <button class="btn btn-light dropdown-toggle" type="button" id="profileMenu" data-bs-toggle="dropdown" aria-expanded="false">
           Admin
         </button>
         <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="profileMenu">
-          <li><a class="dropdown-item" href="#">Profile</a></li>
-          <li><a class="dropdown-item" href="#">Settings</a></li>
+          <li><a class="dropdown-item" href="/admin/profile">Profile</a></li>
+          <li><a class="dropdown-item" href="/admin/settings">Settings</a></li>
           <li><hr class="dropdown-divider"></li>
           <li><a class="dropdown-item" href="/admin/logout">Logout</a></li>
         </ul>

--- a/views/admin/add-villa.html
+++ b/views/admin/add-villa.html
@@ -46,26 +46,16 @@
   <div class="main-content">
     <div class="topbar d-flex justify-content-between align-items-center">
       <button class="btn btn-light" id="sidebarToggle">&#9776;</button>
-    <a href="#">Finance</a>
-    <a href="#">Users Management</a>
-    <a href="#">Settings</a>
-  </div>
-
-  <div class="main-content">
-    <div class="topbar d-flex justify-content-end align-items-center">
       <div class="dropdown">
-        <button class="btn btn-light dropdown-toggle" type="button" id="profileMenu" data-bs-toggle="dropdown" aria-expanded="false">
-          Admin
-        </button>
+        <button class="btn btn-light dropdown-toggle" type="button" id="profileMenu" data-bs-toggle="dropdown" aria-expanded="false">Admin</button>
         <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="profileMenu">
-          <li><a class="dropdown-item" href="#">Profile</a></li>
-          <li><a class="dropdown-item" href="#">Settings</a></li>
+          <li><a class="dropdown-item" href="/admin/profile">Profile</a></li>
+          <li><a class="dropdown-item" href="/admin/settings">Settings</a></li>
           <li><hr class="dropdown-divider"></li>
           <li><a class="dropdown-item" href="/admin/logout">Logout</a></li>
         </ul>
       </div>
     </div>
-
     <div class="container py-4">
       <h2 class="mb-4 text-center">Add New Villa</h2>
       <form id="villaForm">

--- a/views/admin/admin-dashboard.html
+++ b/views/admin/admin-dashboard.html
@@ -68,7 +68,7 @@
     <a href="/admin/users">Users Management</a>
     <a href="#">Finance</a>
     <a href="#">Users Management</a>
-    <a href="#">Settings</a>
+    <a href="/admin/settings">Settings</a>
   </div>
 
   <div class="main-content">
@@ -79,8 +79,8 @@
           Admin
         </button>
         <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="profileMenu">
-          <li><a class="dropdown-item" href="#">Profile</a></li>
-          <li><a class="dropdown-item" href="#">Settings</a></li>
+          <li><a class="dropdown-item" href="/admin/profile">Profile</a></li>
+          <li><a class="dropdown-item" href="/admin/settings">Settings</a></li>
           <li><hr class="dropdown-divider"></li>
           <li><a class="dropdown-item" href="/admin/logout">Logout</a></li>
         </ul>
@@ -92,75 +92,84 @@
 
 <div class="row mb-4" id="revenue-section">
   <div class="col-md-4">
+    <a href="/admin/finance" class="text-decoration-none text-dark">
     <div class="card text-center bg-light shadow-sm">
       <div class="card-body">
         <h5 class="card-title">This Year</h5>
         <p class="card-text fw-bold fs-4" id="revenue-year">Loading...</p>
       </div>
-    </div>
+    </div></a>
   </div>
   <div class="col-md-4">
+    <a href="/admin/finance" class="text-decoration-none text-dark">
     <div class="card text-center bg-light shadow-sm">
       <div class="card-body">
         <h5 class="card-title">This Quarter</h5>
         <p class="card-text fw-bold fs-4" id="revenue-quarter">Loading...</p>
       </div>
-    </div>
+    </div></a>
   </div>
   <div class="col-md-4">
+    <a href="/admin/finance" class="text-decoration-none text-dark">
     <div class="card text-center bg-light shadow-sm">
       <div class="card-body">
         <h5 class="card-title">This Month</h5>
         <p class="card-text fw-bold fs-4" id="revenue-month">Loading...</p>
       </div>
-    </div>
+    </div></a>
   </div>
 </div>
 
 
       <div class="row g-4 mb-5">
         <div class="col-md-3">
+          <a href="/admin/rooms/list" class="text-decoration-none">
           <div class="dashboard-tile tile-blue">
             <h3 id="tileRooms">11</h3>
             <p>Total Rooms</p>
-          </div>
+          </div></a>
         </div>
         <div class="col-md-3">
+          <a href="/admin/villas/list" class="text-decoration-none">
           <div class="dashboard-tile tile-green">
             <h3 id="tileVillas">9</h3>
             <p>Total Villas</p>
-          </div>
+          </div></a>
         </div>
         <div class="col-md-3">
+          <a href="/admin/bookings" class="text-decoration-none">
           <div class="dashboard-tile tile-orange">
             <h3 id="tileBookings">6</h3>
             <p>All Bookings</p>
-          </div>
+          </div></a>
         </div>
         <div class="col-md-3">
+          <a href="/admin/bookings?status=confirmed" class="text-decoration-none">
           <div class="dashboard-tile tile-purple">
             <h3 id="tileConfirmed">3</h3>
             <p>Confirmed Bookings</p>
-          </div>
+          </div></a>
         </div>
       </div>
 
       <div class="row g-4 mb-4">
         <div class="col-md-6">
+          <a href="/admin/bookings" class="text-decoration-none text-dark">
           <div class="card">
             <div class="card-header">Recent Room Bookings</div>
               <ul id="recentBookingsList" class="list-group list-group-flush">
               <li class="list-group-item">Loading...</li>
               </ul>
-          </div>
+          </div></a>
         </div>
         <div class="col-md-6">
+          <a href="/admin/finance" class="text-decoration-none text-dark">
           <div class="card">
             <div class="card-header">Monthly Sales Chart</div>
             <div class="card-body">
               <canvas id="salesChart"></canvas>
             </div>
-          </div>
+          </div></a>
         </div>
       </div>
     </div>

--- a/views/admin/edit-room.html
+++ b/views/admin/edit-room.html
@@ -31,20 +31,13 @@
   <div class="main-content">
     <div class="topbar d-flex justify-content-between align-items-center">
       <button class="btn btn-light" id="sidebarToggle">&#9776;</button>
-    <a href="#">Finance</a>
-    <a href="#">Users Management</a>
-    <a href="#">Settings</a>
-  </div>
-
-  <div class="main-content">
-    <div class="topbar d-flex justify-content-end align-items-center">
       <div class="dropdown">
         <button class="btn btn-light dropdown-toggle" type="button" id="profileMenu" data-bs-toggle="dropdown" aria-expanded="false">
           Admin
         </button>
         <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="profileMenu">
-          <li><a class="dropdown-item" href="#">Profile</a></li>
-          <li><a class="dropdown-item" href="#">Settings</a></li>
+          <li><a class="dropdown-item" href="/admin/profile">Profile</a></li>
+          <li><a class="dropdown-item" href="/admin/settings">Settings</a></li>
           <li><hr class="dropdown-divider"></li>
           <li><a class="dropdown-item" href="/admin/logout">Logout</a></li>
         </ul>

--- a/views/admin/edit-villa.html
+++ b/views/admin/edit-villa.html
@@ -30,20 +30,13 @@
   <div class="main-content">
     <div class="topbar d-flex justify-content-between align-items-center">
       <button class="btn btn-light" id="sidebarToggle">&#9776;</button>
-    <a href="#">Finance</a>
-    <a href="#">Users Management</a>
-    <a href="#">Settings</a>
-  </div>
-
-  <div class="main-content">
-    <div class="topbar d-flex justify-content-end align-items-center">
       <div class="dropdown">
         <button class="btn btn-light dropdown-toggle" type="button" id="profileMenu" data-bs-toggle="dropdown" aria-expanded="false">
           Admin
         </button>
         <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="profileMenu">
-          <li><a class="dropdown-item" href="#">Profile</a></li>
-          <li><a class="dropdown-item" href="#">Settings</a></li>
+          <li><a class="dropdown-item" href="/admin/profile">Profile</a></li>
+          <li><a class="dropdown-item" href="/admin/settings">Settings</a></li>
           <li><hr class="dropdown-divider"></li>
           <li><a class="dropdown-item" href="/admin/logout">Logout</a></li>
         </ul>

--- a/views/admin/finance.html
+++ b/views/admin/finance.html
@@ -22,18 +22,13 @@
   <div class="main-content">
     <div class="topbar d-flex justify-content-between align-items-center">
       <button class="btn btn-light" id="sidebarToggle">&#9776;</button>
-    <a href="#">Settings</a>
-  </div>
-
-  <div class="main-content">
-    <div class="topbar d-flex justify-content-end align-items-center">
       <div class="dropdown">
         <button class="btn btn-light dropdown-toggle" type="button" id="profileMenu" data-bs-toggle="dropdown" aria-expanded="false">
           Admin
         </button>
         <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="profileMenu">
-          <li><a class="dropdown-item" href="#">Profile</a></li>
-          <li><a class="dropdown-item" href="#">Settings</a></li>
+          <li><a class="dropdown-item" href="/admin/profile">Profile</a></li>
+          <li><a class="dropdown-item" href="/admin/settings">Settings</a></li>
           <li><hr class="dropdown-divider"></li>
           <li><a class="dropdown-item" href="/admin/logout">Logout</a></li>
         </ul>
@@ -42,8 +37,11 @@
 
     <div class="container py-4">
       <h2 class="mb-4">Finance Overview</h2>
-      <p>This section will show revenue reports and financial statistics.</p>
-      <div class="alert alert-info">Finance dashboard coming soon...</div>
+      <table class="table" id="financeTable">
+        <thead><tr><th>Villa</th><th>Room</th><th>Total Price</th><th>Status</th></tr></thead>
+        <tbody></tbody>
+      </table>
+      <p class="mt-3"><strong>Total Revenue: <span id="totalRevenue">0</span></strong></p>
     </div>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
@@ -62,7 +60,25 @@
           document.querySelector('.main-content').classList.toggle('collapsed');
         });
       }
+
+      loadFinance();
     });
+
+    async function loadFinance() {
+      const res = await fetch('/api/bookings');
+      const bookings = await res.json();
+      const tbody = document.querySelector('#financeTable tbody');
+      tbody.innerHTML = '';
+      let total = 0;
+      bookings.forEach(b => {
+        const price = b.totalPrice || 0;
+        total += price;
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${b.villaName || '-'}</td><td>${b.roomName || '-'}</td><td>${price}</td><td>${b.status}</td>`;
+        tbody.appendChild(tr);
+      });
+      document.getElementById('totalRevenue').textContent = total;
+    }
   </script>
     </div> <!-- end container -->
   </div> <!-- end main-content -->

--- a/views/admin/list-bookings.html
+++ b/views/admin/list-bookings.html
@@ -51,21 +51,13 @@
   <div class="main-content">
     <div class="topbar d-flex justify-content-between align-items-center">
       <button class="btn btn-light" id="sidebarToggle">&#9776;</button>
-    <a href="#">Finance</a>
-    <a href="#">Users Management</a>
-    <a href="#">Settings</a>
-  </div>
-
-  <div class="main-content">
-    <div class="topbar d-flex justify-content-end align-items-center">
-
       <div class="dropdown">
         <button class="btn btn-light dropdown-toggle" type="button" id="profileMenu" data-bs-toggle="dropdown" aria-expanded="false">
           Admin
         </button>
         <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="profileMenu">
-          <li><a class="dropdown-item" href="#">Profile</a></li>
-          <li><a class="dropdown-item" href="#">Settings</a></li>
+          <li><a class="dropdown-item" href="/admin/profile">Profile</a></li>
+          <li><a class="dropdown-item" href="/admin/settings">Settings</a></li>
           <li><hr class="dropdown-divider"></li>
           <li><a class="dropdown-item" href="/admin/logout">Logout</a></li>
         </ul>
@@ -221,7 +213,8 @@ function showBookingDetail(b) {
   `;
 }
 
-let selectedStatus = '';
+const params = new URLSearchParams(window.location.search);
+let selectedStatus = params.get('status') || '';
 
 function applyFilters() {
   const term = document.getElementById('searchInput').value.toLowerCase();
@@ -380,12 +373,19 @@ if (sortField) {
     });
 
     const toggle = document.getElementById('sidebarToggle');
-    if (toggle) {
-      toggle.addEventListener('click', () => {
-        document.querySelector('.sidebar').classList.toggle('collapsed');
-        document.querySelector('.main-content').classList.toggle('collapsed');
-      });
-    }
+      if (toggle) {
+        toggle.addEventListener('click', () => {
+          document.querySelector('.sidebar').classList.toggle('collapsed');
+          document.querySelector('.main-content').classList.toggle('collapsed');
+        });
+      }
+
+      const activeTab = document.querySelector(`#statusTabs .nav-link[data-status="${selectedStatus}"]`);
+      if (activeTab) {
+        document.querySelector('#statusTabs .nav-link.active')?.classList.remove('active');
+        activeTab.classList.add('active');
+        applyFilters();
+      }
   });
 </script>
 

--- a/views/admin/list-rooms.html
+++ b/views/admin/list-rooms.html
@@ -50,22 +50,13 @@
   <div class="main-content">
     <div class="topbar d-flex justify-content-between align-items-center">
       <button class="btn btn-light" id="sidebarToggle">&#9776;</button>
-
-    <a href="#">Finance</a>
-    <a href="#">Users Management</a>
-    <a href="#">Settings</a>
-  </div>
-
-  <div class="main-content">
-    <div class="topbar d-flex justify-content-end align-items-center">
-
       <div class="dropdown">
         <button class="btn btn-light dropdown-toggle" type="button" id="profileMenu" data-bs-toggle="dropdown" aria-expanded="false">
           Admin
         </button>
         <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="profileMenu">
-          <li><a class="dropdown-item" href="#">Profile</a></li>
-          <li><a class="dropdown-item" href="#">Settings</a></li>
+          <li><a class="dropdown-item" href="/admin/profile">Profile</a></li>
+          <li><a class="dropdown-item" href="/admin/settings">Settings</a></li>
           <li><hr class="dropdown-divider"></li>
           <li><a class="dropdown-item" href="/admin/logout">Logout</a></li>
         </ul>
@@ -79,9 +70,6 @@
         <a href="/admin/rooms/add" class="btn btn-success">
           <i class="fas fa-plus"></i> Add Room
         </a>
-        <a href="/admin/villas/list" class="btn btn-outline-secondary">
-          <i class="fas fa-arrow-left"></i> Back to Villas
-        </a>
       </div>
     </div>
 
@@ -93,18 +81,17 @@
     const villaId = urlParams.get('villa');
 
     async function loadRooms() {
-      const res = await fetch('/api/rooms');
+      const res = await fetch(`/api/rooms?villaId=${villaId}`);
       const rooms = await res.json();
       const list = document.getElementById('roomList');
       list.innerHTML = '';
 
-      const filtered = rooms.filter(r => r.villaId === villaId);
-      if (!filtered.length) {
+      if (!rooms.length) {
         list.innerHTML = '<p class="text-muted">No rooms added yet for this villa.</p>';
         return;
       }
 
-      filtered.forEach(room => {
+      rooms.forEach(room => {
         const col = document.createElement('div');
         col.className = 'col-md-6';
         col.innerHTML = `

--- a/views/admin/list-villas.html
+++ b/views/admin/list-villas.html
@@ -49,21 +49,13 @@
   <div class="main-content">
     <div class="topbar d-flex justify-content-between align-items-center">
       <button class="btn btn-light" id="sidebarToggle">&#9776;</button>
-
-    <a href="#">Finance</a>
-    <a href="#">Users Management</a>
-    <a href="#">Settings</a>
-  </div>
-
-  <div class="main-content">
-    <div class="topbar d-flex justify-content-end align-items-center">
       <div class="dropdown">
         <button class="btn btn-light dropdown-toggle" type="button" id="profileMenu" data-bs-toggle="dropdown" aria-expanded="false">
           Admin
         </button>
         <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="profileMenu">
-          <li><a class="dropdown-item" href="#">Profile</a></li>
-          <li><a class="dropdown-item" href="#">Settings</a></li>
+          <li><a class="dropdown-item" href="/admin/profile">Profile</a></li>
+          <li><a class="dropdown-item" href="/admin/settings">Settings</a></li>
           <li><hr class="dropdown-divider"></li>
           <li><a class="dropdown-item" href="/admin/logout">Logout</a></li>
         </ul>
@@ -76,9 +68,6 @@
       <div>
         <a href="/admin/villas/add" class="btn btn-success">
           <i class="fas fa-plus"></i> Add Villa
-        </a>
-        <a href="/public-home.html" target="_blank" class="btn btn-outline-secondary">
-          <i class="fas fa-eye"></i> View as Customer
         </a>
       </div>
     </div>

--- a/views/admin/profile.html
+++ b/views/admin/profile.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Profile</title>
+  <link rel="stylesheet" href="/public/css/admin.css">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+</head>
+<body>
+  <div class="sidebar">
+    <h5 class="text-center">Admin Menu</h5>
+    <a href="/admin/dashboard">Dashboard</a>
+    <a href="/admin/villas/list">Manage Villas</a>
+    <a href="/admin/rooms/list">Manage Rooms</a>
+    <a href="/admin/bookings">Bookings</a>
+    <a href="/admin/finance">Finance</a>
+    <a href="/admin/users">Users Management</a>
+  </div>
+  <div class="main-content">
+    <div class="topbar d-flex justify-content-between align-items-center">
+      <button class="btn btn-light" id="sidebarToggle">&#9776;</button>
+      <div class="dropdown">
+        <button class="btn btn-light dropdown-toggle" type="button" id="profileMenu" data-bs-toggle="dropdown" aria-expanded="false">Admin</button>
+        <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="profileMenu">
+          <li><a class="dropdown-item" href="/admin/profile">Profile</a></li>
+          <li><a class="dropdown-item" href="/admin/settings">Settings</a></li>
+          <li><hr class="dropdown-divider"></li>
+          <li><a class="dropdown-item" href="/admin/logout">Logout</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="container py-4">
+      <h2 class="mb-4">Profile</h2>
+      <p>This is a placeholder profile page.</p>
+    </div>
+  </div>
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+  const path = window.location.pathname;
+  document.querySelectorAll('.sidebar a').forEach(a => {
+    if (a.getAttribute('href') === path) a.classList.add('active');
+  });
+  const toggle = document.getElementById('sidebarToggle');
+  if (toggle) toggle.addEventListener('click', () => {
+    document.querySelector('.sidebar').classList.toggle('collapsed');
+    document.querySelector('.main-content').classList.toggle('collapsed');
+  });
+});
+</script>
+</body>
+</html>

--- a/views/admin/settings.html
+++ b/views/admin/settings.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Settings</title>
+  <link rel="stylesheet" href="/public/css/admin.css">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+</head>
+<body>
+  <div class="sidebar">
+    <h5 class="text-center">Admin Menu</h5>
+    <a href="/admin/dashboard">Dashboard</a>
+    <a href="/admin/villas/list">Manage Villas</a>
+    <a href="/admin/rooms/list">Manage Rooms</a>
+    <a href="/admin/bookings">Bookings</a>
+    <a href="/admin/finance">Finance</a>
+    <a href="/admin/users">Users Management</a>
+  </div>
+  <div class="main-content">
+    <div class="topbar d-flex justify-content-between align-items-center">
+      <button class="btn btn-light" id="sidebarToggle">&#9776;</button>
+      <div class="dropdown">
+        <button class="btn btn-light dropdown-toggle" type="button" id="profileMenu" data-bs-toggle="dropdown" aria-expanded="false">Admin</button>
+        <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="profileMenu">
+          <li><a class="dropdown-item" href="/admin/profile">Profile</a></li>
+          <li><a class="dropdown-item" href="/admin/settings">Settings</a></li>
+          <li><hr class="dropdown-divider"></li>
+          <li><a class="dropdown-item" href="/admin/logout">Logout</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="container py-4">
+      <h2 class="mb-4">Settings</h2>
+      <p>This is a placeholder settings page.</p>
+    </div>
+  </div>
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+  const path = window.location.pathname;
+  document.querySelectorAll('.sidebar a').forEach(a => {
+    if (a.getAttribute('href') === path) a.classList.add('active');
+  });
+  const toggle = document.getElementById('sidebarToggle');
+  if (toggle) toggle.addEventListener('click', () => {
+    document.querySelector('.sidebar').classList.toggle('collapsed');
+    document.querySelector('.main-content').classList.toggle('collapsed');
+  });
+});
+</script>
+</body>
+</html>

--- a/views/admin/users.html
+++ b/views/admin/users.html
@@ -23,20 +23,13 @@
   <div class="main-content">
     <div class="topbar d-flex justify-content-between align-items-center">
       <button class="btn btn-light" id="sidebarToggle">&#9776;</button>
-
-    <a href="#">Settings</a>
-  </div>
-
-  <div class="main-content">
-    <div class="topbar d-flex justify-content-end align-items-center">
-
       <div class="dropdown">
         <button class="btn btn-light dropdown-toggle" type="button" id="profileMenu" data-bs-toggle="dropdown" aria-expanded="false">
           Admin
         </button>
         <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="profileMenu">
-          <li><a class="dropdown-item" href="#">Profile</a></li>
-          <li><a class="dropdown-item" href="#">Settings</a></li>
+          <li><a class="dropdown-item" href="/admin/profile">Profile</a></li>
+          <li><a class="dropdown-item" href="/admin/settings">Settings</a></li>
           <li><hr class="dropdown-divider"></li>
           <li><a class="dropdown-item" href="/admin/logout">Logout</a></li>
         </ul>
@@ -45,8 +38,23 @@
 
     <div class="container py-4">
       <h2 class="mb-4">User Management</h2>
-      <p>This section will manage users and roles.</p>
-      <div class="alert alert-info">User management dashboard coming soon...</div>
+      <table class="table" id="userTable">
+        <thead><tr><th>Username</th><th>Role</th></tr></thead>
+        <tbody></tbody>
+      </table>
+      <hr>
+      <h5>Add User</h5>
+      <form id="userForm" class="row g-2">
+        <div class="col-md-4"><input type="text" class="form-control" name="username" placeholder="Username" required></div>
+        <div class="col-md-4"><input type="password" class="form-control" name="password" placeholder="Password" required></div>
+        <div class="col-md-3">
+          <select class="form-select" name="role" required>
+            <option value="admin">admin</option>
+            <option value="staff">staff</option>
+          </select>
+        </div>
+        <div class="col-md-1"><button class="btn btn-primary w-100" type="submit">Add</button></div>
+      </form>
     </div>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
@@ -57,7 +65,6 @@
         }
       });
 
-
       const toggle = document.getElementById('sidebarToggle');
       if (toggle) {
         toggle.addEventListener('click', () => {
@@ -66,7 +73,28 @@
         });
       }
 
+      loadUsers();
+      document.getElementById('userForm').addEventListener('submit', async e => {
+        e.preventDefault();
+        const form = e.target;
+        const data = { username: form.username.value, password: form.password.value, role: form.role.value };
+        await fetch('/api/users', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(data) });
+        form.reset();
+        loadUsers();
+      });
     });
+
+    async function loadUsers() {
+      const res = await fetch('/api/users');
+      const users = await res.json();
+      const tbody = document.querySelector('#userTable tbody');
+      tbody.innerHTML = '';
+      users.forEach(u => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${u.username}</td><td>${u.role}</td>`;
+        tbody.appendChild(tr);
+      });
+    }
   </script>
     </div> <!-- end container -->
   </div> <!-- end main-content -->


### PR DESCRIPTION
## Summary
- tidy admin HTML layouts and remove duplicated topbars
- make dashboard tiles and cards link to relevant pages
- add profile and settings pages with routes
- fix rooms page to fetch with villaId parameter
- implement basic user management API and interface
- add simple finance table
- restrict `/admin/users` access to admins

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6842a06ac244832aaf3ac643a7984e25